### PR TITLE
add image pull secrets for internal registry

### DIFF
--- a/deployment.yaml
+++ b/deployment.yaml
@@ -27,6 +27,8 @@ spec:
       labels:
         app: greenhouse
     spec:
+      imagePullSecrets:
+      - name: pipeline-docker-registry
       containers:
       - name: maven
         image: ${CICD_LOCAL_REGISTRY}/example-greenhouse:${CICD_EXECUTION_SEQUENCE}


### PR DESCRIPTION
Use pull secrets in deployment manifests once internal registry authentication is enabled.